### PR TITLE
SOLR-16698: Throw a clearer error message for typos in the feature-store and model-store endpoints (PUT method)

### DIFF
--- a/solr/core/src/java/org/apache/solr/rest/RestManager.java
+++ b/solr/core/src/java/org/apache/solr/rest/RestManager.java
@@ -317,13 +317,12 @@ public class RestManager {
         if ("PUT".equals(method) || "POST".equals(method)) {
           // check for typos in the feature-store or model-store endpoints (like features-store or
           // models-store)
-          if (restManager.managed.containsKey("/schema/feature-store")
-              || restManager.managed.containsKey("/schema/model-store")) {
-            if (!restManager.managed.containsKey(resourceId)) {
-              throw new SolrException(
-                  ErrorCode.BAD_REQUEST,
-                  "No REST managed resource registered for path " + resourceId);
-            }
+          if (!restManager.managed.containsKey(resourceId)
+              && (restManager.managed.containsKey("/schema/feature-store")
+                  || restManager.managed.containsKey("/schema/model-store"))) {
+            throw new SolrException(
+                ErrorCode.BAD_REQUEST,
+                "No REST managed resource registered for path " + resourceId);
           }
           // delegate create requests to the RestManager
           managedResource = restManager.endpoint;

--- a/solr/core/src/java/org/apache/solr/rest/RestManager.java
+++ b/solr/core/src/java/org/apache/solr/rest/RestManager.java
@@ -315,6 +315,16 @@ public class RestManager {
       if (managedResource == null) {
         final String method = getSolrRequest().getHttpMethod();
         if ("PUT".equals(method) || "POST".equals(method)) {
+          // check for typos in the feature-store or model-store endpoints (like features-store or
+          // models-store)
+          if (restManager.managed.containsKey("/schema/feature-store")
+              || restManager.managed.containsKey("/schema/model-store")) {
+            if (!restManager.managed.containsKey(resourceId)) {
+              throw new SolrException(
+                  ErrorCode.BAD_REQUEST,
+                  "No REST managed resource registered for path " + resourceId);
+            }
+          }
           // delegate create requests to the RestManager
           managedResource = restManager.endpoint;
         } else {

--- a/solr/core/src/test/org/apache/solr/rest/TestRestManager.java
+++ b/solr/core/src/test/org/apache/solr/rest/TestRestManager.java
@@ -124,7 +124,6 @@ public class TestRestManager extends SolrRestletTestBase {
     assertJQ("/schema/managed", "/responseHeader/status==0");
     assertHead("/schema/managed", 200);
 
-    // add a ManagedWordSetResource for managing german stop words
     String newEndpoint = "/schema/analysis/stopwords/italian";
     String newEndpointWithTypo = "/schema/analysiss/stopwords/italian";
 
@@ -139,16 +138,13 @@ public class TestRestManager extends SolrRestletTestBase {
         "/managedResources/[2]/resourceId=='/schema/analysis/stopwords/italian'");
     assertHead("/schema/managed", 200);
 
-    // add a word to the managedResource created
-    assertJPut(newEndpoint, Utils.toJSONString(Arrays.asList("ma")), "/responseHeader/status==0");
-
     // add a word to a non-existent managedResource
     assertJPut(
         newEndpointWithTypo,
         Utils.toJSONString(Arrays.asList("ma")),
         "/error/msg=='Trying to put the payload for a non-existent ManagedResource. Check for a typo in the endpoint or create the new ManagedResource before pushing data'");
 
-    // delete the one we created above
+    // delete the one created above
     assertJDelete(newEndpoint, "/responseHeader/status==0");
 
     // delete a non-existent resource

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
@@ -204,7 +204,7 @@ public class TestModelManager extends TestRerankBase {
   }
 
   @Test
-  public void testFeatureStoreEndpointWithTypo_GETMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_GETFeatureStore_shouldThrowException() throws Exception {
     String featureStoreEndpointWithTypo = "/schema/features-store";
     String featureStoreEndpointWithTypoAndStoreName = "/schema/features-store/store1";
 
@@ -221,7 +221,7 @@ public class TestModelManager extends TestRerankBase {
   }
 
   @Test
-  public void testModelStoreEndpointWithTypo_GETMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_GETModelStore_shouldThrowException() throws Exception {
     String modelStoreEndpointWithTypo = "/schema/models-store";
     String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
 
@@ -238,31 +238,45 @@ public class TestModelManager extends TestRerankBase {
   }
 
   @Test
-  public void testFeatureStoreEndpointWithTypo_PUTMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_PUTFeatureStore_shouldThrowException() throws Exception {
     String featureStoreEndpointWithTypo = "/schema/features-store";
 
+    final String valueFeatureClassName = ValueFeature.class.getName();
+
+    // Add features
+    final String multipleFeatures =
+        "[{\"name\": \"test1\", \"class\": \""
+            + valueFeatureClassName
+            + "\", \"params\": {\"value\": 1} }"
+            + ",{\"name\": \"test2\", \"class\": \""
+            + valueFeatureClassName
+            + "\", \"params\": {\"value\": 2} } ]";
     assertJPut(
         featureStoreEndpointWithTypo,
-        json("{ 'class':'solr.ManagedFeatureStore' }"),
-        "/error/msg=='No REST managed resource registered for path "
-            + featureStoreEndpointWithTypo
-            + "'");
+        multipleFeatures,
+        "/error/msg=='Trying to put the payload for a non-existent ManagedResource. Check for a typo in the endpoint or create the new ManagedResource before pushing data'");
   }
 
   @Test
-  public void testModelStoreEndpointWithTypo_PUTMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_PUTModelStore_shouldThrowException() throws Exception {
     String modelStoreEndpointWithTypo = "/schema/models-store";
+
+    final String linearModelClassName = LinearModel.class.getName();
+
+    String model =
+        "{ \"name\":\"testModel1\", \"class\":\""
+            + linearModelClassName
+            + "\", \"features\":[{\"name\":\"test1\"}, {\"name\":\"test2\"}],\"params\":{\"weights\":{\"test1\":1.5,\"test2\":2.0}} }";
 
     assertJPut(
         modelStoreEndpointWithTypo,
-        json("{ 'class':'solr.ManagedModelStore' }"),
-        "/error/msg=='No REST managed resource registered for path "
-            + modelStoreEndpointWithTypo
-            + "'");
+        model,
+        "/error/msg=='Trying to put the payload for a non-existent ManagedResource. Check for a typo in the endpoint or create the new ManagedResource before pushing data'");
   }
 
   @Test
-  public void testFeatureStoreEndpointWithTypo_DELETEMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_DELETEFeatureStore_shouldThrowException()
+      throws Exception {
     String featureStoreEndpointWithTypoAndStoreName = "/schema/features-store/store1";
 
     assertJDelete(
@@ -273,7 +287,8 @@ public class TestModelManager extends TestRerankBase {
   }
 
   @Test
-  public void testModelStoreEndpointWithTypo_DELETEMethod() throws Exception {
+  public void restManagerEndpointsWithTypo_DELETEModelStore_shouldThrowException()
+      throws Exception {
     String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
 
     assertJDelete(

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
@@ -202,4 +202,58 @@ public class TestModelManager extends TestRerankBase {
     restTestHarness.delete(
         ManagedFeatureStore.REST_END_POINT + "/" + FeatureStore.DEFAULT_FEATURE_STORE_NAME);
   }
+
+  @Test
+  public void testRestManagerEndpointsWithTypo() throws Exception {
+    String featureStoreEndpointWithTypo = "/schema/features-store";
+    String featureStoreEndpointWithTypoAndStoreName = "/schema/features-store/store1";
+    String modelStoreEndpointWithTypo = "/schema/models-store";
+    String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
+
+    assertJQ(
+        featureStoreEndpointWithTypo,
+        "/error/msg=='No REST managed resource registered for path "
+            + featureStoreEndpointWithTypo
+            + "'");
+    assertJQ(
+        featureStoreEndpointWithTypoAndStoreName,
+        "/error/msg=='No REST managed resource registered for path "
+            + featureStoreEndpointWithTypoAndStoreName
+            + "'");
+    assertJQ(
+        modelStoreEndpointWithTypo,
+        "/error/msg=='No REST managed resource registered for path "
+            + modelStoreEndpointWithTypo
+            + "'");
+    assertJQ(
+        modelStoreEndpointWithTypoAndModelName,
+        "/error/msg=='No REST managed resource registered for path "
+            + modelStoreEndpointWithTypoAndModelName
+            + "'");
+
+    assertJPut(
+        featureStoreEndpointWithTypo,
+        json("{ 'class':'solr.ManagedFeatureStore' }"),
+        "/error/msg=='No REST managed resource registered for path "
+            + featureStoreEndpointWithTypo
+            + "'");
+
+    assertJPut(
+        modelStoreEndpointWithTypo,
+        json("{ 'class':'solr.ManagedModelStore' }"),
+        "/error/msg=='No REST managed resource registered for path "
+            + modelStoreEndpointWithTypo
+            + "'");
+
+    assertJDelete(
+        featureStoreEndpointWithTypoAndStoreName,
+        "/error/msg=='No REST managed resource registered for path "
+            + featureStoreEndpointWithTypoAndStoreName
+            + "'");
+    assertJDelete(
+        modelStoreEndpointWithTypoAndModelName,
+        "/error/msg=='No REST managed resource registered for path "
+            + modelStoreEndpointWithTypoAndModelName
+            + "'");
+  }
 }

--- a/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
+++ b/solr/modules/ltr/src/test/org/apache/solr/ltr/store/rest/TestModelManager.java
@@ -204,11 +204,9 @@ public class TestModelManager extends TestRerankBase {
   }
 
   @Test
-  public void testRestManagerEndpointsWithTypo() throws Exception {
+  public void testFeatureStoreEndpointWithTypo_GETMethod() throws Exception {
     String featureStoreEndpointWithTypo = "/schema/features-store";
     String featureStoreEndpointWithTypoAndStoreName = "/schema/features-store/store1";
-    String modelStoreEndpointWithTypo = "/schema/models-store";
-    String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
 
     assertJQ(
         featureStoreEndpointWithTypo,
@@ -220,6 +218,13 @@ public class TestModelManager extends TestRerankBase {
         "/error/msg=='No REST managed resource registered for path "
             + featureStoreEndpointWithTypoAndStoreName
             + "'");
+  }
+
+  @Test
+  public void testModelStoreEndpointWithTypo_GETMethod() throws Exception {
+    String modelStoreEndpointWithTypo = "/schema/models-store";
+    String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
+
     assertJQ(
         modelStoreEndpointWithTypo,
         "/error/msg=='No REST managed resource registered for path "
@@ -230,6 +235,11 @@ public class TestModelManager extends TestRerankBase {
         "/error/msg=='No REST managed resource registered for path "
             + modelStoreEndpointWithTypoAndModelName
             + "'");
+  }
+
+  @Test
+  public void testFeatureStoreEndpointWithTypo_PUTMethod() throws Exception {
+    String featureStoreEndpointWithTypo = "/schema/features-store";
 
     assertJPut(
         featureStoreEndpointWithTypo,
@@ -237,6 +247,11 @@ public class TestModelManager extends TestRerankBase {
         "/error/msg=='No REST managed resource registered for path "
             + featureStoreEndpointWithTypo
             + "'");
+  }
+
+  @Test
+  public void testModelStoreEndpointWithTypo_PUTMethod() throws Exception {
+    String modelStoreEndpointWithTypo = "/schema/models-store";
 
     assertJPut(
         modelStoreEndpointWithTypo,
@@ -244,12 +259,23 @@ public class TestModelManager extends TestRerankBase {
         "/error/msg=='No REST managed resource registered for path "
             + modelStoreEndpointWithTypo
             + "'");
+  }
+
+  @Test
+  public void testFeatureStoreEndpointWithTypo_DELETEMethod() throws Exception {
+    String featureStoreEndpointWithTypoAndStoreName = "/schema/features-store/store1";
 
     assertJDelete(
         featureStoreEndpointWithTypoAndStoreName,
         "/error/msg=='No REST managed resource registered for path "
             + featureStoreEndpointWithTypoAndStoreName
             + "'");
+  }
+
+  @Test
+  public void testModelStoreEndpointWithTypo_DELETEMethod() throws Exception {
+    String modelStoreEndpointWithTypoAndModelName = "/schema/models-store/model1";
+
     assertJDelete(
         modelStoreEndpointWithTypoAndModelName,
         "/error/msg=='No REST managed resource registered for path "


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16698

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

When a PUT request is made with a typo in either the "feature-store" or "model-store" endpoint, an unclear error message is received. This can occur when there is an additional "s" added to the "feature-store" endpoint, for example. The goal is to improve error handling by providing a more descriptive exception message that helps users better understand the mistake they made.

# Solution

Upon examination of the RestManager portion, it appears that when attempting to insert payloads for a nonexistent ManagedResource  (either due to a typo or because it has not yet been configured), the **doPut** method in _org/apache/solr/rest/**RestManager**.java_ (only responsible for creating a new ManagedResource in the RestManager) is used instead of the **doPut** method in _org/apache/solr/rest/**ManagedResource**.java_ (which is responsible for handling the insertion of request payloads).

The doPut method's exception in _RestManager.java_ has been modified such that a new ManagedResource is only created if the 'json' object is an instance of Map and contains a single key named class. Otherwise, it indicates that an "error" has occurred and that the ManagedResource does not exist because it has not yet been configured or because of a typo.

# Tests

Added a test named **_testRestManagerEndpointsWithTypo_** in _TestRestManager.java_ to check the put and delete requests when a typo is made in the (stopwords) endpoint. 

Added several small tests in _TestModelManager.java_ to check the get, put, and delete requests of the feature store and model store when a typo is made in the endpoint. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
